### PR TITLE
Fix silence method name on docs

### DIFF
--- a/API/programable.md
+++ b/API/programable.md
@@ -195,7 +195,7 @@ dbm.reset()
 });
 ```
 
-## silent(isSilent)
+## silence(isSilent)
 
 Silences or unsilences logs.
 
@@ -207,7 +207,7 @@ __Examples__
 
 ```javascript
 var dbm = dbmigrate.getInstance(true);
-dbm.silent(true);
+dbm.silence(true);
 dbm.reset();
 ```
 


### PR DESCRIPTION
The current documentation states the method is called [silent](https://db-migrate.readthedocs.io/en/latest/API/programable/#silentissilent) but it's actually [silence](https://github.com/db-migrate/node-db-migrate/blob/41628f758de62d7bc18e3958ddd84ede833f2fbd/api.js#L380).

This fixes it =)