### PR TITLE
Fix indentation in programmable.md

### DIFF
--- a/docs/API/programable.md
+++ b/docs/API/programable.md
@@ -67,9 +67,9 @@ __Options__
 
 * cwd - working directory (default: process.cwd)
 * config
-  * string - location of the database.json file
-  * object - hash of [configuration](https://umigrate.readthedocs.org/projects/db-migrate/en/latest/Getting%20Started/configuration/) options
-  * cmdOptions - hash of CMD options from [Basic Usage](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/installation/)
+     - string - location of the database.json file
+     - object - hash of [configuration](https://umigrate.readthedocs.org/projects/db-migrate/en/latest/Getting%20Started/configuration/) options
+* cmdOptions - hash of CMD options from [Basic Usage](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/installation/)
 * env - the environment to run the migrations under
 * throwUncatched - Throw an error instead of calling `process.exit(1)`
 


### PR DESCRIPTION
Type of arguments that can be passed in place of **options** were not properly shown in the docs.