### PR TITLE
Include port config and ssl config in examples

### DIFF
--- a/docs/Getting Started/configuration.md
+++ b/docs/Getting Started/configuration.md
@@ -26,6 +26,8 @@ db-migrate supports the concept of environments. For example, you might have a d
     "password": "test",
     "host": "localhost",
     "database": "mydb",
+    "port": "20144",
+    "ssl": "true",
     "schema": "my_schema"
   },
 


### PR DESCRIPTION
Added what appears to be undocumented config options for defining a non-standard port as well as enforcing SSL connection.