### PR TITLE
https://github.com/db-migrate/english-docs/issues/16

### DIFF
--- a/docs/Getting Started/configuration.md
+++ b/docs/Getting Started/configuration.md
@@ -139,3 +139,9 @@ If you use MySQL, to be able to use multiple statements in your sql file, you ha
   }
 }
 ```
+
+## Important - For Postgresql (PSQL) users
+You'll need to install db-migrate-pg which provides the psql driver:
+```
+npm install --save db-migrate-pg
+```


### PR DESCRIPTION
Added config requirements for db-migrate-pg
Postgres users also need to have psql driver install.  Updating DOCs to reflect this requirement.
https://github.com/db-migrate/english-docs/issues/16