### PR TITLE
Update `ssl` configuration example for postgres

### DIFF
--- a/docs/Getting Started/configuration.md
+++ b/docs/Getting Started/configuration.md
@@ -27,7 +27,7 @@ db-migrate supports the concept of environments. For example, you might have a d
     "host": "localhost",
     "database": "mydb",
     "port": "20144",
-    "ssl": "true",
+    "ssl": true,
     "schema": "my_schema"
   },
 


### PR DESCRIPTION
Documentation about `ssl` option example for postgres driver is misleading. It is expected to be boolean either `true` | `false`. String value: `"true"`, will be treat as `true` for sure, but `"false"` will also be treat as `true`.

References:
https://github.com/brianc/node-postgres/blob/2ef55503738eb2cbb6326744381a92c0bc0439ab/packages/pg/lib/connection-parameters.js#L71