### PR TITLE
"ssl" config value should be boolean

### DIFF
--- a/docs/Getting Started/configuration.md
+++ b/docs/Getting Started/configuration.md
@@ -27,7 +27,7 @@ db-migrate supports the concept of environments. For example, you might have a d
     "host": "localhost",
     "database": "mydb",
     "port": "20144",
-    "ssl": "true",
+    "ssl": true,
     "schema": "my_schema"
   },
 


### PR DESCRIPTION
This is my first time using this library, so disregard if I'm totally off-base here, but I kept running into issues locally on the latest version (`db-migrate@0.11.12`, `db-migrate-pg@1.2.2`, `pg@8.5.1`), with an error:

> "The server does not support SSL connections"

despite having `"ssl": "false"` in this config file.

From what I can gather, this should be a boolean value instead of a string, as the underlying `pg` lib depends on that. I found this recent PR which led me to that conclusion:
 - https://github.com/brianc/node-postgres/pull/2394/files#diff-cc6abc00177b0fba133f7ea7b2fbe025fc21e789f243cfd85f9be7e0325f0bc2R83-R89

#### Changes included:
 - Use boolean for "ssl" config values in documentation

**Before:** using `"ssl": "false"` in config caused "The server does not support SSL connections" fatal error
**After:** everything works as expected with `"ssl": false` config value